### PR TITLE
refactor: rename app to service, rename module to github.com/adikhoironhasan/go-simple-template

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ internal/
 │           ├── repository/   → Database port interfaces
 │           └── cache/        → Cache port interfaces
 │
-├── app/                      → Application services (use cases)
+├── service/                      → Application services (use cases)
 │   ├── health/               → Health check use case
 │   └── auth/                 → User authentication (register, login, refresh, logout, profile)
 │
@@ -175,7 +175,7 @@ go test ./...
 go test -v ./...
 
 # Run specific package
-go test -v ./internal/app/health/...
+go test -v ./internal/service/health/...
 ```
 
 ## Key Design Decisions

--- a/cmd/api/rest/cmd.go
+++ b/cmd/api/rest/cmd.go
@@ -7,16 +7,16 @@ import (
 	"os/signal"
 	"syscall"
 
-	"go-simple-template/internal/adapter/inbound/rest/router"
-	"go-simple-template/internal/adapter/inbound/rest/server"
-	healthCache "go-simple-template/internal/adapter/outbound/cache/redis/health"
-	tokenCacheAdapter "go-simple-template/internal/adapter/outbound/cache/redis/token"
-	healthRepo "go-simple-template/internal/adapter/outbound/repository/mongo/health"
-	userRepo "go-simple-template/internal/adapter/outbound/repository/mongo/user"
-	"go-simple-template/internal/infrastructure"
-	"go-simple-template/internal/pkg/config"
-	authService "go-simple-template/internal/service/auth"
-	healthService "go-simple-template/internal/service/health"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/router"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/server"
+	healthCache "github.com/adikhoironhasan/go-simple-template/internal/adapter/outbound/cache/redis/health"
+	tokenCacheAdapter "github.com/adikhoironhasan/go-simple-template/internal/adapter/outbound/cache/redis/token"
+	healthRepo "github.com/adikhoironhasan/go-simple-template/internal/adapter/outbound/repository/mongo/health"
+	userRepo "github.com/adikhoironhasan/go-simple-template/internal/adapter/outbound/repository/mongo/user"
+	"github.com/adikhoironhasan/go-simple-template/internal/infrastructure"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/config"
+	authService "github.com/adikhoironhasan/go-simple-template/internal/service/auth"
+	healthService "github.com/adikhoironhasan/go-simple-template/internal/service/health"
 )
 
 func Start(ctx context.Context) {

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,9 +5,9 @@ import (
 	"log"
 	"log/slog"
 
-	"go-simple-template/cmd/api/rest"
-	"go-simple-template/internal/infrastructure"
-	"go-simple-template/internal/pkg/config"
+	"github.com/adikhoironhasan/go-simple-template/cmd/api/rest"
+	"github.com/adikhoironhasan/go-simple-template/internal/infrastructure"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/config"
 
 	"github.com/spf13/cobra"
 )

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module go-simple-template
+module github.com/adikhoironhasan/go-simple-template
 
 go 1.26.2
 

--- a/internal/adapter/inbound/rest/dto/auth.go
+++ b/internal/adapter/inbound/rest/dto/auth.go
@@ -3,7 +3,7 @@ package dto
 import (
 	"time"
 
-	"go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 	"github.com/go-ozzo/ozzo-validation/v4/is"

--- a/internal/adapter/inbound/rest/dto/health.go
+++ b/internal/adapter/inbound/rest/dto/health.go
@@ -1,6 +1,6 @@
 package dto
 
-import "go-simple-template/internal/core/domain/entity"
+import "github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
 
 type CheckHealthRequest struct {
 	MongoDB bool `query:"mongodb"`

--- a/internal/adapter/inbound/rest/dto/validation.go
+++ b/internal/adapter/inbound/rest/dto/validation.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"go-simple-template/internal/pkg/consts"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/consts"
 
 	validation "github.com/go-ozzo/ozzo-validation/v4"
 )

--- a/internal/adapter/inbound/rest/handler/auth/auth.go
+++ b/internal/adapter/inbound/rest/handler/auth/auth.go
@@ -1,7 +1,7 @@
 package auth
 
 import (
-	"go-simple-template/internal/core/port/inbound"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/port/inbound"
 )
 
 type AuthHandler struct {

--- a/internal/adapter/inbound/rest/handler/auth/login.go
+++ b/internal/adapter/inbound/rest/handler/auth/login.go
@@ -4,9 +4,9 @@ import (
 	"log/slog"
 	"net/http"
 
-	"go-simple-template/internal/adapter/inbound/rest/dto"
-	"go-simple-template/internal/adapter/inbound/rest/utils"
-	"go-simple-template/internal/pkg/consts"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/dto"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/utils"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/consts"
 
 	"github.com/labstack/echo/v4"
 )

--- a/internal/adapter/inbound/rest/handler/auth/logout.go
+++ b/internal/adapter/inbound/rest/handler/auth/logout.go
@@ -4,9 +4,9 @@ import (
 	"log/slog"
 	"net/http"
 
-	"go-simple-template/internal/adapter/inbound/rest/dto"
-	"go-simple-template/internal/adapter/inbound/rest/utils"
-	"go-simple-template/internal/pkg/consts"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/dto"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/utils"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/consts"
 
 	"github.com/labstack/echo/v4"
 )

--- a/internal/adapter/inbound/rest/handler/auth/profile.go
+++ b/internal/adapter/inbound/rest/handler/auth/profile.go
@@ -4,11 +4,11 @@ import (
 	"log/slog"
 	"net/http"
 
-	"go-simple-template/internal/adapter/inbound/rest/dto"
-	"go-simple-template/internal/adapter/inbound/rest/utils"
-	"go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/dto"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/utils"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
 
-	ctxpkg "go-simple-template/internal/pkg/context"
+	ctxpkg "github.com/adikhoironhasan/go-simple-template/internal/pkg/context"
 
 	"github.com/labstack/echo/v4"
 )

--- a/internal/adapter/inbound/rest/handler/auth/refresh_token.go
+++ b/internal/adapter/inbound/rest/handler/auth/refresh_token.go
@@ -4,9 +4,9 @@ import (
 	"log/slog"
 	"net/http"
 
-	"go-simple-template/internal/adapter/inbound/rest/dto"
-	"go-simple-template/internal/adapter/inbound/rest/utils"
-	"go-simple-template/internal/pkg/consts"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/dto"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/utils"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/consts"
 
 	"github.com/labstack/echo/v4"
 )

--- a/internal/adapter/inbound/rest/handler/auth/register.go
+++ b/internal/adapter/inbound/rest/handler/auth/register.go
@@ -4,9 +4,9 @@ import (
 	"log/slog"
 	"net/http"
 
-	"go-simple-template/internal/adapter/inbound/rest/dto"
-	"go-simple-template/internal/adapter/inbound/rest/utils"
-	"go-simple-template/internal/pkg/consts"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/dto"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/utils"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/consts"
 
 	"github.com/labstack/echo/v4"
 )

--- a/internal/adapter/inbound/rest/handler/health/check_health.go
+++ b/internal/adapter/inbound/rest/handler/health/check_health.go
@@ -4,9 +4,9 @@ import (
 	"log/slog"
 	"net/http"
 
-	"go-simple-template/internal/adapter/inbound/rest/dto"
-	"go-simple-template/internal/adapter/inbound/rest/utils"
-	"go-simple-template/internal/pkg/consts"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/dto"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/utils"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/consts"
 
 	"github.com/labstack/echo/v4"
 )

--- a/internal/adapter/inbound/rest/handler/health/health.go
+++ b/internal/adapter/inbound/rest/handler/health/health.go
@@ -1,6 +1,6 @@
 package health
 
-import "go-simple-template/internal/core/port/inbound"
+import "github.com/adikhoironhasan/go-simple-template/internal/core/port/inbound"
 
 type handler struct {
 	healthService inbound.HealthService

--- a/internal/adapter/inbound/rest/middleware/echo.go
+++ b/internal/adapter/inbound/rest/middleware/echo.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"log/slog"
 
-	"go-simple-template/internal/pkg/consts"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/consts"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"

--- a/internal/adapter/inbound/rest/middleware/jwt.go
+++ b/internal/adapter/inbound/rest/middleware/jwt.go
@@ -4,10 +4,10 @@ import (
 	"net/http"
 	"strings"
 
-	"go-simple-template/internal/adapter/inbound/rest/dto"
-	"go-simple-template/internal/pkg/jwt"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/dto"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/jwt"
 
-	ctxpkg "go-simple-template/internal/pkg/context"
+	ctxpkg "github.com/adikhoironhasan/go-simple-template/internal/pkg/context"
 
 	"github.com/labstack/echo/v4"
 )

--- a/internal/adapter/inbound/rest/router/router.go
+++ b/internal/adapter/inbound/rest/router/router.go
@@ -3,12 +3,12 @@ package router
 import (
 	"context"
 
-	"go-simple-template/internal/adapter/inbound/rest/middleware"
-	"go-simple-template/internal/core/port/inbound"
-	"go-simple-template/internal/pkg/config"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/middleware"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/port/inbound"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/config"
 
-	authHandler "go-simple-template/internal/adapter/inbound/rest/handler/auth"
-	healthHandler "go-simple-template/internal/adapter/inbound/rest/handler/health"
+	authHandler "github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/handler/auth"
+	healthHandler "github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/handler/health"
 
 	"github.com/labstack/echo/v4"
 )

--- a/internal/adapter/inbound/rest/server/server.go
+++ b/internal/adapter/inbound/rest/server/server.go
@@ -7,8 +7,8 @@ import (
 	"net/http"
 	"time"
 
-	"go-simple-template/internal/adapter/inbound/rest/router"
-	"go-simple-template/internal/pkg/config"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/inbound/rest/router"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/config"
 )
 
 type server struct {

--- a/internal/adapter/inbound/rest/utils/errmap.go
+++ b/internal/adapter/inbound/rest/utils/errmap.go
@@ -3,7 +3,7 @@ package utils
 import (
 	"net/http"
 
-	"go-simple-template/internal/pkg/errs"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/errs"
 )
 
 // codeToHTTP maps domain error codes to HTTP status codes.

--- a/internal/adapter/outbound/cache/redis/health/check_health.go
+++ b/internal/adapter/outbound/cache/redis/health/check_health.go
@@ -2,7 +2,7 @@ package health
 
 import (
 	"context"
-	"go-simple-template/internal/pkg/consts"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/consts"
 	"log/slog"
 )
 

--- a/internal/adapter/outbound/cache/redis/token/blacklist.go
+++ b/internal/adapter/outbound/cache/redis/token/blacklist.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"time"
 
-	"go-simple-template/internal/pkg/consts"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/consts"
 )
 
 func (c *cacheRepo) Blacklist(ctx context.Context, token string, expiration time.Duration) error {

--- a/internal/adapter/outbound/cache/redis/token/is_blacklisted.go
+++ b/internal/adapter/outbound/cache/redis/token/is_blacklisted.go
@@ -6,7 +6,7 @@ import (
 	"encoding/hex"
 	"log/slog"
 
-	"go-simple-template/internal/pkg/consts"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/consts"
 )
 
 func (c *cacheRepo) IsBlacklisted(ctx context.Context, token string) (bool, error) {

--- a/internal/adapter/outbound/repository/mongo/health/check_health.go
+++ b/internal/adapter/outbound/repository/mongo/health/check_health.go
@@ -2,7 +2,7 @@ package health
 
 import (
 	"context"
-	"go-simple-template/internal/pkg/consts"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/consts"
 	"log/slog"
 )
 

--- a/internal/adapter/outbound/repository/mongo/model/user.go
+++ b/internal/adapter/outbound/repository/mongo/model/user.go
@@ -1,7 +1,7 @@
 package model
 
 import (
-	"go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
 )

--- a/internal/adapter/outbound/repository/mongo/user/find_one.go
+++ b/internal/adapter/outbound/repository/mongo/user/find_one.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"errors"
 
-	"go-simple-template/internal/adapter/outbound/repository/mongo/model"
-	"go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/outbound/repository/mongo/model"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
 
-	errpkg "go-simple-template/internal/pkg/errs"
+	errpkg "github.com/adikhoironhasan/go-simple-template/internal/pkg/errs"
 
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"

--- a/internal/adapter/outbound/repository/mongo/user/insert.go
+++ b/internal/adapter/outbound/repository/mongo/user/insert.go
@@ -3,9 +3,9 @@ package user
 import (
 	"context"
 
-	"go-simple-template/internal/adapter/outbound/repository/mongo/model"
-	"go-simple-template/internal/core/domain/entity"
-	"go-simple-template/internal/pkg/errs"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/outbound/repository/mongo/model"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/errs"
 
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"

--- a/internal/adapter/outbound/repository/mongo/user/user.go
+++ b/internal/adapter/outbound/repository/mongo/user/user.go
@@ -1,7 +1,7 @@
 package user
 
 import (
-	"go-simple-template/internal/adapter/outbound/repository/mongo/model"
+	"github.com/adikhoironhasan/go-simple-template/internal/adapter/outbound/repository/mongo/model"
 	"go.mongodb.org/mongo-driver/mongo"
 )
 

--- a/internal/core/port/inbound/auth.go
+++ b/internal/core/port/inbound/auth.go
@@ -3,7 +3,7 @@ package inbound
 import (
 	"context"
 
-	"go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
 )
 
 //go:generate mockgen -package mocks -source=auth.go -destination=mocks/auth_mock.go AuthService

--- a/internal/core/port/inbound/health.go
+++ b/internal/core/port/inbound/health.go
@@ -2,7 +2,7 @@ package inbound
 
 import (
 	"context"
-	"go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
 )
 
 //go:generate mockgen -package mocks -source=health.go -destination=mocks/health_mock.go HealthService

--- a/internal/core/port/inbound/mocks/auth_mock.go
+++ b/internal/core/port/inbound/mocks/auth_mock.go
@@ -11,9 +11,9 @@ package mocks
 
 import (
 	context "context"
-	entity "go-simple-template/internal/core/domain/entity"
 	reflect "reflect"
 
+	entity "github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/internal/core/port/inbound/mocks/health_mock.go
+++ b/internal/core/port/inbound/mocks/health_mock.go
@@ -11,9 +11,9 @@ package mocks
 
 import (
 	context "context"
-	entity "go-simple-template/internal/core/domain/entity"
 	reflect "reflect"
 
+	entity "github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/internal/core/port/outbound/repository/mocks/user_mock.go
+++ b/internal/core/port/outbound/repository/mocks/user_mock.go
@@ -11,9 +11,9 @@ package mocks
 
 import (
 	context "context"
-	entity "go-simple-template/internal/core/domain/entity"
 	reflect "reflect"
 
+	entity "github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
 	gomock "go.uber.org/mock/gomock"
 )
 

--- a/internal/core/port/outbound/repository/user.go
+++ b/internal/core/port/outbound/repository/user.go
@@ -3,7 +3,7 @@ package repository
 import (
 	"context"
 
-	"go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
 )
 
 //go:generate mockgen -package mocks -source=user.go -destination=mocks/user_mock.go UserRepository

--- a/internal/infrastructure/mongodb.go
+++ b/internal/infrastructure/mongodb.go
@@ -5,8 +5,8 @@ import (
 	"fmt"
 	"log/slog"
 
-	"go-simple-template/internal/pkg/config"
-	"go-simple-template/internal/pkg/consts"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/config"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/consts"
 
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"

--- a/internal/infrastructure/redis.go
+++ b/internal/infrastructure/redis.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"log/slog"
 
-	"go-simple-template/internal/pkg/config"
-	"go-simple-template/internal/pkg/consts"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/config"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/consts"
 
 	red "github.com/redis/go-redis/v9"
 )

--- a/internal/infrastructure/slog.go
+++ b/internal/infrastructure/slog.go
@@ -5,7 +5,7 @@ import (
 	"log/slog"
 	"os"
 
-	"go-simple-template/internal/pkg/consts"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/consts"
 )
 
 // NewSlog initializes the slog logger with the specified log level.

--- a/internal/pkg/context/context.go
+++ b/internal/pkg/context/context.go
@@ -2,8 +2,8 @@ package context
 
 import (
 	"context"
-	"go-simple-template/internal/core/domain/entity"
-	"go-simple-template/internal/pkg/consts"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/consts"
 )
 
 func SetUserCtx(ctx context.Context, userCtx *entity.UserCtx) context.Context {

--- a/internal/pkg/jwt/jwt.go
+++ b/internal/pkg/jwt/jwt.go
@@ -6,9 +6,9 @@ import (
 	"log/slog"
 	"time"
 
-	"go-simple-template/internal/core/domain/entity"
-	"go-simple-template/internal/pkg/config"
-	errpkg "go-simple-template/internal/pkg/errs"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/config"
+	errpkg "github.com/adikhoironhasan/go-simple-template/internal/pkg/errs"
 
 	jwtgo "github.com/golang-jwt/jwt/v5"
 )

--- a/internal/pkg/jwt/type.go
+++ b/internal/pkg/jwt/type.go
@@ -1,7 +1,7 @@
 package jwt
 
 import (
-	"go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
 
 	jwtgo "github.com/golang-jwt/jwt/v5"
 )

--- a/internal/service/auth/auth.go
+++ b/internal/service/auth/auth.go
@@ -1,8 +1,8 @@
 package auth
 
 import (
-	"go-simple-template/internal/core/port/outbound/cache"
-	"go-simple-template/internal/core/port/outbound/repository"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/port/outbound/cache"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/port/outbound/repository"
 )
 
 type auth struct {

--- a/internal/service/auth/auth_test.go
+++ b/internal/service/auth/auth_test.go
@@ -3,10 +3,10 @@ package auth
 import (
 	"testing"
 
-	"go-simple-template/internal/core/domain/entity"
-	cacheMocks "go-simple-template/internal/core/port/outbound/cache/mocks"
-	repoMocks "go-simple-template/internal/core/port/outbound/repository/mocks"
-	"go-simple-template/internal/pkg/jwt"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
+	cacheMocks "github.com/adikhoironhasan/go-simple-template/internal/core/port/outbound/cache/mocks"
+	repoMocks "github.com/adikhoironhasan/go-simple-template/internal/core/port/outbound/repository/mocks"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/jwt"
 
 	"github.com/spf13/viper"
 	"github.com/stretchr/testify/require"

--- a/internal/service/auth/login.go
+++ b/internal/service/auth/login.go
@@ -4,10 +4,10 @@ import (
 	"context"
 	"log/slog"
 
-	"go-simple-template/internal/core/domain/entity"
-	"go-simple-template/internal/pkg/crypto"
-	errpkg "go-simple-template/internal/pkg/errs"
-	"go-simple-template/internal/pkg/jwt"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/crypto"
+	errpkg "github.com/adikhoironhasan/go-simple-template/internal/pkg/errs"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/jwt"
 )
 
 func (s *auth) Login(ctx context.Context, request entity.User) (*entity.AuthToken, error) {

--- a/internal/service/auth/login_test.go
+++ b/internal/service/auth/login_test.go
@@ -2,9 +2,9 @@ package auth
 
 import (
 	"context"
-	"go-simple-template/internal/core/domain/entity"
-	"go-simple-template/internal/pkg/crypto"
-	"go-simple-template/internal/pkg/errs"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/crypto"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/errs"
 	"testing"
 
 	"github.com/stretchr/testify/assert"

--- a/internal/service/auth/logout.go
+++ b/internal/service/auth/logout.go
@@ -5,10 +5,10 @@ import (
 	"log/slog"
 	"time"
 
-	"go-simple-template/internal/core/domain/entity"
-	"go-simple-template/internal/pkg/consts"
-	errpkg "go-simple-template/internal/pkg/errs"
-	"go-simple-template/internal/pkg/jwt"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/consts"
+	errpkg "github.com/adikhoironhasan/go-simple-template/internal/pkg/errs"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/jwt"
 )
 
 func (s *auth) Logout(ctx context.Context, request entity.AuthToken) error {

--- a/internal/service/auth/logout_test.go
+++ b/internal/service/auth/logout_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"go-simple-template/internal/core/domain/entity"
-	"go-simple-template/internal/pkg/errs"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/errs"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/service/auth/profile.go
+++ b/internal/service/auth/profile.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"log/slog"
 
-	"go-simple-template/internal/core/domain/entity"
-	errpkg "go-simple-template/internal/pkg/errs"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
+	errpkg "github.com/adikhoironhasan/go-simple-template/internal/pkg/errs"
 )
 
 func (s *auth) Profile(ctx context.Context, request entity.AuthToken) (*entity.User, error) {

--- a/internal/service/auth/profile_test.go
+++ b/internal/service/auth/profile_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"go-simple-template/internal/core/domain/entity"
-	"go-simple-template/internal/pkg/errs"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/errs"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/service/auth/refresh_token.go
+++ b/internal/service/auth/refresh_token.go
@@ -5,10 +5,10 @@ import (
 	"log/slog"
 	"time"
 
-	"go-simple-template/internal/core/domain/entity"
-	"go-simple-template/internal/pkg/consts"
-	errpkg "go-simple-template/internal/pkg/errs"
-	"go-simple-template/internal/pkg/jwt"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/consts"
+	errpkg "github.com/adikhoironhasan/go-simple-template/internal/pkg/errs"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/jwt"
 )
 
 func (s *auth) RefreshToken(ctx context.Context, request entity.AuthToken) (*entity.AuthToken, error) {

--- a/internal/service/auth/refresh_token_test.go
+++ b/internal/service/auth/refresh_token_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"go-simple-template/internal/core/domain/entity"
-	"go-simple-template/internal/pkg/errs"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/errs"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/service/auth/register.go
+++ b/internal/service/auth/register.go
@@ -4,9 +4,9 @@ import (
 	"context"
 	"log/slog"
 
-	"go-simple-template/internal/core/domain/entity"
-	"go-simple-template/internal/pkg/crypto"
-	errpkg "go-simple-template/internal/pkg/errs"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/crypto"
+	errpkg "github.com/adikhoironhasan/go-simple-template/internal/pkg/errs"
 )
 
 func (s *auth) Register(ctx context.Context, request entity.User) (*entity.User, error) {

--- a/internal/service/auth/register_test.go
+++ b/internal/service/auth/register_test.go
@@ -4,8 +4,8 @@ import (
 	"context"
 	"testing"
 
-	"go-simple-template/internal/core/domain/entity"
-	"go-simple-template/internal/pkg/errs"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/errs"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"

--- a/internal/service/health/check_health.go
+++ b/internal/service/health/check_health.go
@@ -6,8 +6,8 @@ import (
 	"log/slog"
 	"sync"
 
-	"go-simple-template/internal/core/domain/entity"
-	"go-simple-template/internal/pkg/consts"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/pkg/consts"
 
 	"golang.org/x/sync/errgroup"
 )

--- a/internal/service/health/check_health_test.go
+++ b/internal/service/health/check_health_test.go
@@ -5,7 +5,7 @@ import (
 	"errors"
 	"testing"
 
-	"go-simple-template/internal/core/domain/entity"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/domain/entity"
 
 	"github.com/samber/lo"
 	"github.com/stretchr/testify/assert"

--- a/internal/service/health/health.go
+++ b/internal/service/health/health.go
@@ -1,8 +1,8 @@
 package health
 
 import (
-	"go-simple-template/internal/core/port/outbound/cache"
-	"go-simple-template/internal/core/port/outbound/repository"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/port/outbound/cache"
+	"github.com/adikhoironhasan/go-simple-template/internal/core/port/outbound/repository"
 )
 
 type service struct {

--- a/internal/service/health/health_test.go
+++ b/internal/service/health/health_test.go
@@ -3,8 +3,8 @@ package health
 import (
 	"testing"
 
-	cacheMocks "go-simple-template/internal/core/port/outbound/cache/mocks"
-	repoMocks "go-simple-template/internal/core/port/outbound/repository/mocks"
+	cacheMocks "github.com/adikhoironhasan/go-simple-template/internal/core/port/outbound/cache/mocks"
+	repoMocks "github.com/adikhoironhasan/go-simple-template/internal/core/port/outbound/repository/mocks"
 
 	"go.uber.org/mock/gomock"
 )


### PR DESCRIPTION
## Summary

- **Rename module** from `go-simple-template` to `github.com/adikhoironhasan/go-simple-template` across all 55 Go source files
- **Rename `internal/app/` → `internal/service/`** to better reflect the application service layer in hexagonal architecture

## Key Changes

| Area | Before | After |
|------|--------|-------|
| Module | `go-simple-template` | `github.com/adikhoironhasan/go-simple-template` |
| Service layer | `internal/app/` | `internal/service/` |

## Test Plan

- [x] `go build ./...` passes
- [x] All 119 import paths updated consistently

🤖 Generated with [Claude Code](https://claude.com/claude-code)